### PR TITLE
Add backupsnapassoc script

### DIFF
--- a/scripts/backupsnapassoc/README.md
+++ b/scripts/backupsnapassoc/README.md
@@ -1,0 +1,20 @@
+# backupsnapassoc
+
+Reads existing snapshot schedule associations defined by Spectrum Scale GUI, and writes them to stdout in a format which can be used to re-apply them later. Optionally deletes all snapshot schedule associations - ensure that you save the output so that you can later re-apply the rules...
+
+This is particularly useful for upgrades, as creation and deletion of snapshots using `mmcrsnapshot` and `mmdelsnapshot` needs to be stopped during the upgrade window.
+
+To simply backup all existing snapshot schedule associations:
+```
+./backupsnapassoc.sh > snapassocs.sh
+```
+
+To backup all snapshot schedule associations and then delete them (run this before the upgrade):
+```
+./backupsnapassoc.sh --delete > snapassocs.sh
+```
+
+To re-apply all snapshot schedule associations (run this after the upgrade):
+```
+./snapassocs.sh
+```

--- a/scripts/backupsnapassoc/backupsnapassoc.sh
+++ b/scripts/backupsnapassoc/backupsnapassoc.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+################################################################################
+# Name:            backupsnapassoc.sh
+# Author:          Achim Christ - achim(dot)christ(at)gmail(dot)com
+# Version:         1.0
+################################################################################
+
+# Commandline arguments:
+#   --delete       - Also delete snapshot associations
+
+# Return codes:
+#   0              - Success
+#   1              - Error deleting snapshot associations
+#   2              - Warning, nothing to do
+
+# Treat unset variables as error
+set -u
+
+# Echo to stderr
+echoerr() { echo "$@" 1>&2; }
+
+# Constants
+readonly GUI_PATH="/usr/lpp/mmfs/gui/cli"
+
+# Use sudo if not running as root
+PREFIX=""
+if [ "$(whoami)" != "root" ]; then
+  PREFIX="sudo "
+fi
+
+# Read snapshot associations
+OUT=$( ${PREFIX}${GUI_PATH}/lssnapassoc -Y | grep -v "HEADER" )
+
+# Check if any snapshot associations exist
+if [ "$OUT" == "" ]; then
+  echoerr "No snapshot schedule associations found!"
+  exit 2
+fi
+
+# Write script header to stdout
+echo "#!/bin/bash"
+
+# Parse snapshot associations
+echo "$OUT" | while read -r line || [ -n "$line" ]; do
+
+  # Extract details
+  DEVICE=$( echo "$line" | cut -d ':' -f 8 )
+  FILESET=$( echo "$line" | cut -d ':' -f 9 )
+  RULE=$( echo "$line" | cut -d ':' -f 10 )
+
+  # Compile backup command
+  BKP_CMD="${PREFIX}${GUI_PATH}/mksnapassoc ${DEVICE} ${RULE}"
+
+  # Compile delete command
+  DEL_CMD="${PREFIX}${GUI_PATH}/rmsnapassoc ${DEVICE} ${RULE}"
+
+  # Optionally append fileset to commands
+  if [ ! -z "$FILESET" ]; then
+    BKP_CMD+=" -j ${FILESET}"
+    DEL_CMD+=" -j ${FILESET}"
+  fi
+
+  # Append further parameters to delete command
+  DEL_CMD+=" -k -f &> /dev/null"
+
+  # Write backup command to stdout
+  echo "$BKP_CMD"
+
+  # Optionally run delete command
+  if [ "${1:-}" == "--delete" ]; then
+    if ! eval "$DEL_CMD"; then
+      echoerr "Error deleting snapshot association - try running following command manually:"
+      echoerr "$DEL_CMD"
+      exit 1
+    fi
+  fi
+
+done
+
+exit 0


### PR DESCRIPTION
I came up with the following script to backup-, and restore the Spectrum Scale GUI snapshot schedules during upgrades. Creation and deletion of snapshots should be suspended during the upgrade window, and this script helps with that. Refer to the [README](https://github.com/acch/gpfsug-tools/blob/master/scripts/backupsnapassoc/README.md) for details.